### PR TITLE
Print exception message on panic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,9 @@ int main(int argv, char** args) {
     } catch (const Json::LogicError&) {
         SDL_Log("Configuration file invalid, please delete it");
         return EXIT_FAILURE;
+    } catch (const std::runtime_error &e) {
+        SDL_Log("Error: %s", e.what());
+        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
When running the game in the Dolphin emulator, the panic() function just quits the game without printing anything. By capturing the exception and logging via SDL_Log(), we ensure that the error will be visible.