### PR TITLE
Add point for shells in multiple matches

### DIFF
--- a/src/BoardManager.cpp
+++ b/src/BoardManager.cpp
@@ -550,8 +550,8 @@ void BoardManager::drawIntroduction(SDL_Renderer * renderer) {
 
 bool BoardManager::isDoubleMatch(Match match) {
     for(Match m : this->matches_made) {
-        if (m.direction != match.direction) {
-            if (m.direction == Direction::HORIZONTAL) {
+        if (m.match_type != match.match_type) {
+            if (m.match_type == MatchType::HORIZONTAL) {
                 if (m.x+1 == match.x && m.y == match.y+1) {
                     return true;
                 }
@@ -592,6 +592,10 @@ void BoardManager::drawMatches(SDL_Renderer * renderer) {
             current_shell_size = (this->options->getShellSize()*(MATCH_STEPS-animation))/MATCH_STEPS;
         }
         for(int i = 0; i < 3; i++) {
+            // Do not draw extra shells for bonus matches
+            if (match.match_type == MatchType::BONUS) {
+                break;
+            }
             SDL_Rect srcrect;
             srcrect.x = this->options->getShellSize() * (int) match.type;
             srcrect.y = 0;
@@ -604,9 +608,9 @@ void BoardManager::drawMatches(SDL_Renderer * renderer) {
             dstrect.w = current_shell_size;
             dstrect.h = current_shell_size;
 
-            if (match.direction == Direction::HORIZONTAL) {
+            if (match.match_type == MatchType::HORIZONTAL) {
                 dstrect.x += this->options->getShellSize()*i;
-            } else {
+            } else if (match.match_type == MatchType::VERTICAL) {
                 dstrect.y += this->options->getShellSize()*i;
             }
 
@@ -644,9 +648,9 @@ void BoardManager::drawMatches(SDL_Renderer * renderer) {
             SDL_QueryTexture(text, NULL, NULL, &rect_plus_one.w, &rect_plus_one.h);
             rect_plus_one.x += this->options->getShellSize()/2 - rect_plus_one.w/2;
             rect_plus_one.y += this->options->getShellSize()/2 - rect_plus_one.h/2;
-            if (match.direction == Direction::HORIZONTAL) {
+            if (match.match_type == MatchType::HORIZONTAL) {
                 rect_plus_one.x += this->options->getShellSize();
-            } else {
+            } else if (match.match_type == MatchType::VERTICAL) {
                 rect_plus_one.y += this->options->getShellSize();
             }
 

--- a/src/Shell.hpp
+++ b/src/Shell.hpp
@@ -19,16 +19,17 @@ struct Shell {
     int y;
 };
 
-enum class Direction {
+enum class MatchType {
     HORIZONTAL,
-    VERTICAL
+    VERTICAL,
+    BONUS // Having a shell in both a vertical and horizontal match results in a bonus point
 };
 
 struct Match {
     ShellType type;
     int x;
     int y;
-    Direction direction;
+    MatchType match_type;
 };
 
 #endif // SHELL_HPP

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -5,7 +5,7 @@ inline constexpr float ANALOG_DEADZONE_MULTIPLIER = 0.5;
 
 inline constexpr int DROP_TIME = 300; // in ms
 
-inline constexpr int MATCH_TIME = 500; // in ms
+inline constexpr int MATCH_TIME = 2000; // in ms
 inline constexpr int MATCH_STEPS = 100;
 inline constexpr float MATCH_DELAY = MATCH_TIME/MATCH_STEPS;
 


### PR DESCRIPTION
I don't know if this is something that I really want to be in the game, but it feels kinda wrong that matching horizontal and vertical at the same time does not give an extra point. I don't know how I would document this in the how to play screens.